### PR TITLE
Fixes

### DIFF
--- a/zcash/__init__.py
+++ b/zcash/__init__.py
@@ -45,7 +45,7 @@ class TestNetParams(zcash.core.CoreTestNetParams):
     # ZCPAYMENT_ADDRRESS: guarantees the first 2 characters, when base58 encoded, are "zt"
     BASE58_PREFIXES = {'PUBKEY_ADDR':b'\x1D\x25',
                        'SCRIPT_ADDR':b'\x1C\xBA',
-                       'SECRET_KEY' :b'\xEF',
+                       'SECRET_KEY' :239 # b'\xEF',
                        'ZCPAYMENT_ADDRRESS': b'\x16\xB6'}
 
 class RegTestParams(zcash.core.CoreRegTestParams):
@@ -55,7 +55,7 @@ class RegTestParams(zcash.core.CoreRegTestParams):
     DNS_SEEDS = ()
     BASE58_PREFIXES = {'PUBKEY_ADDR':b'\x1D\x25',
                        'SCRIPT_ADDR':b'\x1C\xBA',
-                       'SECRET_KEY' :b'\xEF',
+                       'SECRET_KEY' :239, # b'\xEF',
                        'ZCPAYMENT_ADDRRESS': b'\x16\xB6'}
 
 """Master global setting for what chain params we're using.

--- a/zcash/__init__.py
+++ b/zcash/__init__.py
@@ -45,7 +45,7 @@ class TestNetParams(zcash.core.CoreTestNetParams):
     # ZCPAYMENT_ADDRRESS: guarantees the first 2 characters, when base58 encoded, are "zt"
     BASE58_PREFIXES = {'PUBKEY_ADDR':b'\x1D\x25',
                        'SCRIPT_ADDR':b'\x1C\xBA',
-                       'SECRET_KEY' :239 # b'\xEF',
+                       'SECRET_KEY' :239, # b'\xEF',
                        'ZCPAYMENT_ADDRRESS': b'\x16\xB6'}
 
 class RegTestParams(zcash.core.CoreRegTestParams):

--- a/zcash/rpc.py
+++ b/zcash/rpc.py
@@ -130,7 +130,9 @@ class BaseProxy(object):
         # __conn being created __del__() can detect the condition and handle it
         # correctly.
         self.__conn = None
-
+        #this line is only good for regtest
+        service_port = 18232
+        
         if service_url is None:
             # Figure out the path to the zcash.conf file
             if zcash_conf_file is None:
@@ -167,14 +169,16 @@ class BaseProxy(object):
 
         self.__service_url = service_url
         self.__url = urlparse.urlparse(service_url)
-
+        print('url ', self.__url)
         if self.__url.scheme not in ('http',):
             raise ValueError('Unsupported URL scheme %r' % self.__url.scheme)
-
+        print('Just before if clause:',self.__url.port)
         if self.__url.port is None:
             port = httplib.HTTP_PORT
+            print('port line 174:', port)
         else:
             port = self.__url.port
+            print("port line 174 else clause:", port)
         self.__id_count = 0
         authpair = "%s:%s" % (self.__url.username, self.__url.password)
         authpair = authpair.encode('utf8')


### PR DESCRIPTION
Bugs fixed: 
Give secret key prefix in int instead of hex (for some reason hex was calling problem)
Make sure to add *one byte* secret key version number.
Revert to older versions of script.py and scripteval.py.
I'm not sure what the rationale of the changed were, but it created bugs, and old versions things seem to work fine. At least they do with the xcat demo.
(Need to discuss this with @str4d at some point)